### PR TITLE
O glorioso gerador de desculpinha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "autoload": {
         "psr-4": {
-            "TwitterSorteator\\": "src/TwitterSorteator/"
+            "TwitterSorteator\\": "src/TwitterSorteator/",
+            "GeradorDesculpinhas\\": "src/GeradorDesculpinhas/"
         }
     },
 

--- a/public/index.php
+++ b/public/index.php
@@ -21,6 +21,8 @@ Sorteio realizado utilizando:
 Twitter Sorteator
 ");
     $urlSorteio = "https://twitter.com/intent/tweet?text=" . $urlSorteio;
+
+    $desculpinha = \GeradorDesculpinhas\GeradorDesculpinhas::getDesculpinha();
 }
 
 ?>
@@ -46,7 +48,7 @@ Twitter Sorteator
 
     <div class="bg-contact2" style="background-image: url('images/bg-01.jpg');">
         <div class="container-contact2">
-            <div class="wrap-contact2">
+            <h3 class="wrap-contact2">
                 <form class="contact2-form validate-form" action="index.php" method="POST">
                     <span class="contact2-form-title">
                         Twitter Sorteator
@@ -111,6 +113,10 @@ Twitter Sorteator
                         <h3>
                             Pessoa sorteada: <a href="<?= $pessoaSorteada ?>"><?= $pessoaSorteada ?></a>
                         </h3>
+                        <br />
+                        <h3>
+                            Desculpinha do dia: <?=  $desculpinha['texto'] ?> de autoria <?= $desculpinha['autoria'] ?>
+                        </h3>
 
                         <div class="container-contact2-form-btn">
                             <div class="wrap-contact2-form-btn">
@@ -120,6 +126,8 @@ Twitter Sorteator
                                 </a>
                             </div>
                         </div>
+
+
                     <?php }
                        else if (!empty($_POST['link']) && empty($twitterSorteator->retweets)) { ?>
 

--- a/src/GeradorDesculpinhas/GeradorDesculpinhas.php
+++ b/src/GeradorDesculpinhas/GeradorDesculpinhas.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace GeradorDesculpinhas;
+
+class GeradorDesculpinhas
+{
+
+    public static function getDesculpinha(): array
+    {
+        $desculpinhas = [
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Eu dei RT mas não tá aparecendo aí'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Minha conta é fechada'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Eu tava indo lá agora mesmo deixar o RT'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Minha Internet caiu'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'null'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'null'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Meu cachorro comeu meu twitter'
+            ],
+            [
+                'autoria' => 'Desconhecida',
+                'texto' => 'Eu tava dormindo'
+            ],
+        ];
+
+        $key = array_rand($desculpinhas);
+
+        return $desculpinhas[$key];
+    }
+}


### PR DESCRIPTION
Você já ouviu todas elas pokemao, então a partir de agora o twitter sorteator gera uma desculpinha aleatória toda vez que rola um sorteio. Assim o público não tem mais desculpa pra não deixar o RT.

![Screenshot - 12_10_2021 , 13_45_26](https://user-images.githubusercontent.com/1254853/136997303-8cc3bad3-7c25-47b7-8d0d-58b9c4b5f9c6.jpg)

